### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pylint
 
 on: 


### PR DESCRIPTION
Potential fix for [https://github.com/guigoruiz1/yugiquery/security/code-scanning/3](https://github.com/guigoruiz1/yugiquery/security/code-scanning/3)

To fix this issue, explicitly set the `permissions` block to restrict the GITHUB_TOKEN used by the workflow to the minimum required for proper operation. In this case, the job only checks out the repository and uploads an artifact, both of which can function with only `contents: read` permissions. The best practice is to add a line specifying `permissions: contents: read` at the top level of the workflow (after `name:` but before `on:`), ensuring that all jobs default to the most restrictive permissions necessary, unless overridden. No other files or lines require changing, and no additional imports or method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
