### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,7 @@
 name: Install
 
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/guigoruiz1/yugiquery/security/code-scanning/2](https://github.com/guigoruiz1/yugiquery/security/code-scanning/2)

To fix the problem, we need to add an explicit `permissions` block to the workflow. This can be done at the root level of the YAML workflow file (above or below the `on:` block) so it applies to all jobs, or within the specific job (e.g., build), if only that job should be restricted. In this case, since the workflow only involves dependency installation and information printing (no write operations), the minimal safe permission is `contents: read`. Therefore, add:

```yaml
permissions:
  contents: read
```

immediately after the `name:` or after the `on:` block in `.github/workflows/install.yml`. No other code changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
